### PR TITLE
Ease manual testing uploading test artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,3 +38,8 @@ jobs:
     - name: Run tests
       run: |
         python -m tests.test
+    - name: Upload test.docx
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-docx-p${{ matrix.python-version }}
+        path: tests/test.docx


### PR DESCRIPTION
Should help in debugging issues across multiple builds (default max retention is 90 days but still better than nothing)

ref #11 