### PR TITLE
feature: inline imgs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,20 @@
 Release History
 ---------------
 
+1.0.7 (2025-XX-XX)
+++++++++++++++++++
+
+**Updates**
+
+- Being able to use inline images on same paragraph. | [Dfop02](https://github.com/dfop02)
+- Add tests for inline images. | [Dfop02](https://github.com/dfop02)
+- Add tests for Bold, Italic, Underline and Strike. | [Dfop02](https://github.com/dfop02)
+
+**Fixes**
+
+- None
+
+
 1.0.6 (2025-05-02)
 ++++++++++++++++++
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ My goal in forking and fixing/updating this package was to complete my current t
 - Support font_size when text, ex.: small, medium, etc. | [Dfop02](https://github.com/dfop02)
 - Support to internal links (Anchor) | [Dfop02](https://github.com/dfop02)
 - Add support to table cells style (border, background-color, width, height, margin) | [Dfop02](https://github.com/dfop02)
+- Being able to use inline images on same paragraph. | [Dfop02](https://github.com/dfop02)
 - Refactory Tests to be more consistent and less 'human validation' | [Dfop02](https://github.com/dfop02)
 
 ## License

--- a/html4docx/h4d.py
+++ b/html4docx/h4d.py
@@ -367,11 +367,12 @@ class HtmlToDocx(HTMLParser):
         # fetch image
         image = utils.fetch_image_data(src)
 
+        self.run = self.paragraph.add_run()
         # add image to doc
         if image:
             try:
                 if isinstance(self.doc, docx.document.Document):
-                    self.doc.add_picture(image, width, height)
+                    self.run.add_picture(image, width, height)
                 else:
                     self.add_image_to_cell(self.doc, image, width, height)
             except FileNotFoundError:

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import unittest
 from docx import Document
 from docx.oxml.ns import qn
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.parts.image import ImagePart
+
 from html4docx import HtmlToDocx
 from html4docx.utils import unit_converter
 from .context import test_dir
@@ -253,7 +256,6 @@ and blank lines.
             'Test: Handling external hyperlink',
             level=1
         )
-        # Add on document for human validation
         self.parser.add_html_to_document(hyperlink_html_example, self.document)
 
         document = self.parser.parse_html_string(hyperlink_html_example)
@@ -277,7 +279,6 @@ and blank lines.
             'Test: Handling internal hyperlink',
             level=1
         )
-        # Add on document for human validation
         self.parser.add_html_to_document(hyperlink_html_example, self.document)
 
         document = self.parser.parse_html_string(hyperlink_html_example)
@@ -291,11 +292,77 @@ and blank lines.
             'Test: Handling img without src',
             level=1
         )
-        # Add on document for human validation
         self.parser.add_html_to_document('<img />', self.document)
 
         document = self.parser.parse_html_string('<img />')
         assert '<image: no_src>' in document.paragraphs[0].text
+
+    def test_inline_images(self):
+        self.document.add_heading(
+            'Test: Handling inline images',
+            level=1
+        )
+        test_img_src = 'https://github.com/dfop02/html4docx/blob/main/tests/assets/images/test_img.png?raw=true'
+        html_example = (
+            f"<p><img src='{test_img_src}' />"
+            f"<img src='{test_img_src}' />"
+            f"<img src='{test_img_src}' /></p>"
+        )
+        self.parser.add_html_to_document(html_example, self.document)
+
+        document = self.parser.parse_html_string(html_example)
+
+        # Find paragraphs containing inline pictures
+        img_paragraphs = [
+            p for p in document.paragraphs
+            if any(r._element.xpath(".//pic:pic") for r in p.runs)
+        ]
+        assert img_paragraphs, "Expected at least one paragraph with inline images"
+
+        first_img_para = img_paragraphs[0]
+        inline_img_runs = [
+            r for r in first_img_para.runs
+            if r._element.xpath(".//pic:pic")
+        ]
+        assert len(inline_img_runs) == 3, "Expected 3 inline image runs in a single paragraph"
+
+    def test_bold_italic_underline_and_strike(self):
+        self.document.add_heading(
+            'Test: Bold, Italic, Underline and Strike tags',
+            level=1
+        )
+
+        html_example = (
+            "<p>This text has <b>Bold Words</b>.</p>"
+            "<p>This text has <i>Italic Words</i>.</p>"
+            "<p>This text has <u>Underline Words</u>.</p>"
+            "<p>This text has <s>Strike Words</s>.</p>"
+            "<p>This text has <b><i><u><s>Bold, Italic, Underline and Strike Words</s></u></i></b>.</p>"
+        )
+        # Add on document for human validation
+        self.parser.add_html_to_document(html_example, self.document)
+
+        document = self.parser.parse_html_string(html_example)
+        paragraphs = document.paragraphs
+
+        self.assertIn("Bold Words", paragraphs[0].text)
+        self.assertTrue(paragraphs[0].runs[2].bold)
+
+        self.assertIn("Italic Words", paragraphs[1].text)
+        self.assertTrue(paragraphs[1].runs[2].italic)
+
+        self.assertIn("Underline Words", paragraphs[2].text)
+        self.assertTrue(paragraphs[2].runs[2].underline)
+
+        self.assertIn("Strike Words", paragraphs[3].text)
+        self.assertTrue(paragraphs[3].runs[2].font.strike)
+
+        self.assertIn("Bold, Italic, Underline and Strike Words", paragraphs[4].text)
+        run = paragraphs[4].runs[2]
+        self.assertTrue(run.bold)
+        self.assertTrue(run.italic)
+        self.assertTrue(run.underline)
+        self.assertTrue(run.font.strike)
 
     def test_font_size(self):
         font_size_html_example = (


### PR DESCRIPTION
## Description

Add inline imgs, previously we're only able to add one image per paragraph, which makes a breakline.

## Issue Reference

None

## Checklist Before Requesting a Review

- [X] I have performed a self-review of my code.
- [X] My code follows the project's coding style and guidelines.
- [X] I have run tests and verified that all existing and new tests pass.
- [X] I have added new tests to cover my changes.
