### PR TITLE
Fix single img crash bug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,23 @@
 Release History
 ---------------
 
+1.0.8 (2025-06-26)
+++++++++++++++++++
+
+**Updates**
+
+- Add tests for local image. | [Dfop02](https://github.com/dfop02)
+- Add tests for unbalanced table. | [Dfop02](https://github.com/dfop02)
+
+**Fixes**
+
+- Fix crash when there is only one image. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/19)
+
+**New Features**
+
+- None
+
+
 1.0.7 (2025-06-17)
 ++++++++++++++++++
 

--- a/html4docx/h4d.py
+++ b/html4docx/h4d.py
@@ -412,7 +412,11 @@ class HtmlToDocx(HTMLParser):
         # fetch image
         image = utils.fetch_image_data(src)
 
+        if not self.paragraph:
+            self.paragraph = self.doc.add_paragraph()
+
         self.run = self.paragraph.add_run()
+
         # add image to doc
         if image:
             try:

--- a/tests/test.py
+++ b/tests/test.py
@@ -295,6 +295,26 @@ and blank lines.
         document = self.parser.parse_html_string('<img />')
         assert '<image: no_src>' in document.paragraphs[0].text
 
+    def test_local_img(self):
+        # A table with more td elements in latter rows than in the first
+        self.document.add_heading('Test: Local Image', level=1)
+        html_local_img = '<img alt="" height="306px" src="./tests/assets/images/test_img.png" width="520px"/>'
+        self.parser.add_html_to_document(html_local_img,self.document)
+        document = self.parser.parse_html_string(html_local_img)
+
+        # Get the last paragraph
+        paragraphs = document.paragraphs
+        image_paragraph = paragraphs[-1]
+
+        # Check the run contains an image
+        image_found = False
+        for run in image_paragraph.runs:
+            if run._element.xpath(".//w:drawing"):
+                image_found = True
+                break
+
+        assert image_found, "No image was found in the document"
+
     def test_inline_images(self):
         self.document.add_heading(
             'Test: Handling inline images',
@@ -636,17 +656,30 @@ and blank lines.
 
     def test_unbalanced_table(self):
         # A table with more td elements in latter rows than in the first
-        self.document.add_heading(
-            'Test: Handling unbalanced tables',
-            level=1
-        )
-        self.parser.add_html_to_document(
-            "<table>"
-            "<tr><td>Hello</td></tr>"
-            "<tr><td>One</td><td>Two</td></tr>"
-            "</table>",
-            self.document
-        )
+        self.document.add_heading('Test: Handling unbalanced tables', level=1)
+
+        html_unbalanced_table = """
+            <table>
+            <tr><td>Hello</td></tr>
+            <tr><td>One</td><td>Two</td></tr>
+            </table>
+        """
+        self.parser.add_html_to_document(html_unbalanced_table, self.document)
+        document = self.parser.parse_html_string(html_unbalanced_table)
+
+        # Get the last table added to the document
+        tables = document.tables
+        assert len(tables) == 1
+
+        # Docx will autofit all cells
+        table = tables[0]
+        assert len(table.rows) == 2
+        assert len(table.rows[0].cells) == 2
+        assert len(table.rows[1].cells) == 2
+
+        assert table.rows[0].cells[0].text.strip() == "Hello"
+        assert table.rows[1].cells[0].text.strip() == "One"
+        assert table.rows[1].cells[1].text.strip() == "Two"
 
     def test_emojis_and_special_characters(self):
         emojis_and_special_chars_html_example = """


### PR DESCRIPTION
## Description

This PR fixes a bug that caused a crash when the HTML input contained only a single image. The issue was introduced after recent changes to the handle_img function, where a new paragraph was no longer always being created for each image. However, the logic still assumed that a paragraph would exist to insert the image into — which led to the crash.

The solution was to check if a paragraph exists before inserting the image. If none exists, a new one is created. This ensures that a paragraph is always available when needed, without unnecessarily creating new ones. As a result, images can still be inserted into the same paragraph when appropriate.

## Issue Reference

Fix single image crash #19 

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding style and guidelines.
- [x] I have run tests and verified that all existing and new tests pass.
- [x] I have added new tests to cover my changes.
