### PR TITLE
Add support for rowspan and colspan in tables

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,24 +3,42 @@
 Release History
 ---------------
 
+
+1.0.9 (2025-07-xx)
+++++++++++++++++++
+
+**Updates**
+
+None
+
+**Fixes**
+
+- Merge missing `Release/1.0.8`. | [Dfop02](https://github.com/dfop02)
+
+**New Features**
+
+Add support for rowspan and colspan in tables. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/25)
+Add support for 'vertical-align' in table cells. | [Dfop02](https://github.com/dfop02)
+
+
 1.0.8 (2025-07-04)
 ++++++++++++++++++
 
 **Updates**
 
-- Add tests for image without paragraph. | [Dfop02](https://github.com/dfop02)
-- Add tests for bookmark without paragraph. | [Dfop02](https://github.com/dfop02)
-- Add tests for local image. | [Dfop02](https://github.com/dfop02)
-- Add tests for unbalanced table. | [Dfop02](https://github.com/dfop02)
+Add tests for image without paragraph. | [Dfop02](https://github.com/dfop02)
+Add tests for bookmark without paragraph. | [Dfop02](https://github.com/dfop02)
+Add tests for local image. | [Dfop02](https://github.com/dfop02)
+Add tests for unbalanced table. | [Dfop02](https://github.com/dfop02)
 
 **Fixes**
 
-- Fix crash when there is bookmark without paragraph. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/21)
-- Fix crash when there is image without paragraph. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/19)
+Fix crash when there is bookmark without paragraph. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/21)
+Fix crash when there is image without paragraph. | [Dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/19)
 
 **New Features**
 
-- None
+None
 
 
 1.0.7 (2025-06-17)

--- a/html4docx/utils.py
+++ b/html4docx/utils.py
@@ -108,6 +108,10 @@ def fetch_image_data(src: str):
             return None
 
 def parse_dict_string(string: str, separator: str = ';'):
+    """Parse style string into dict, return empty dict if no style"""
+    if not string:
+        return dict()
+
     new_string = re.sub(r'\s+', ' ', string.replace("\n", '')).split(separator)
     string_dict = dict((k.strip(), v.strip()) for x in new_string if ':' in x for k, v in [x.split(':')])
     return string_dict


### PR DESCRIPTION
## Description

After verify Issue, I understood that colspan and rowspan was not being supported at the moment, so I worked on this new features to cover tables cells correctly, I believe now is working fine for basic updates.
I also add support for `vertical-align` style, to keep data centrilized on Table Cell, now is possible just by using something like:
`<th rowspan="2" style="vertical-align:middle;text-align:center">Region</th>`

## Issue Reference

Add support for rowspan and colspan from Issue #25 

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding style and guidelines.
- [x] I have run tests and verified that all existing and new tests pass.
- [x] I have added new tests to cover my changes.
