### PR TITLE
feat: add strikethrough support for <del> tag

### DIFF
--- a/html4docx/constants.py
+++ b/html4docx/constants.py
@@ -32,6 +32,7 @@ FONT_STYLES = {
     'i': 'italic',
     'u': 'underline',
     's': 'strike',
+    'del': 'strike',  # HTML5 deletion element - same as <s>
     'sup': 'superscript',
     'sub': 'subscript',
     'th': 'bold'


### PR DESCRIPTION
## Summary
- Adds strikethrough formatting support for the `<del>` HTML element
- Maps `<del>` to `font.strike = True`, same as existing `<s>` tag support

## Background
The `<del>` HTML element represents text that has been deleted from a document. While `<s>` is already supported for strikethrough, `<del>` was missing. Both tags semantically represent struck-through text per HTML specification.

**Example:**
```html
<p>The price was <del>$100</del> now $80!</p>
```

## Changes
- Added `'del': 'strike'` to `FONT_STYLES` in constants.py

## Test plan
- [ ] Verify `<del>text</del>` renders with strikethrough
- [ ] Verify existing `<s>` tag still works
- [ ] Verify nested tags work (e.g., `<del><strong>text</strong></del>`)