### PR TITLE
feat: add support for <mark> (highlight) and <ins> (underline) tags

### DIFF
--- a/html4docx/constants.py
+++ b/html4docx/constants.py
@@ -31,6 +31,7 @@ FONT_STYLES = {
     'em': 'italic',
     'i': 'italic',
     'u': 'underline',
+    'ins': 'underline',  # HTML5 insertion element - underline like <u>
     's': 'strike',
     'sup': 'superscript',
     'sub': 'subscript',

--- a/html4docx/h4d.py
+++ b/html4docx/h4d.py
@@ -1681,6 +1681,19 @@ class HtmlToDocx(HTMLParser):
                 font_name = constants.FONT_NAMES[tag]
                 self.run.font.name = font_name
 
+            # Handle <mark> tag with yellow background highlight
+            if tag == 'mark':
+                shd = OxmlElement('w:shd')
+                shd.set(qn('w:val'), 'clear')
+                shd.set(qn('w:color'), 'auto')
+                shd.set(qn('w:fill'), 'FFFF00')  # Yellow - default <mark> color
+                r_pr = self.run._element.get_or_add_rPr()
+                # Remove existing shading if present
+                existing_shd = r_pr.find(qn('w:shd'))
+                if existing_shd is not None:
+                    r_pr.remove(existing_shd)
+                r_pr.append(shd)
+
             if 'style' in attrs and (tag in ['div', 'li', 'pre']):
                 style = utils.parse_dict_string(attrs['style'])
                 self.add_styles_to_run(style)


### PR DESCRIPTION
## Summary
- Adds `<ins>` tag support with underline formatting (same as `<u>`)
- Adds `<mark>` tag support with yellow background highlight

## Background
These HTML5 semantic elements are commonly used in:
- Markdown-to-HTML converters (e.g., `==highlight==` → `<mark>`)
- Document editing and track changes
- Text comparison tools

### `<ins>` - Insertion
The `<ins>` element represents text that has been added to a document. Per HTML convention, it's typically rendered with underline, same as `<u>`.

**Example:**
```html
<p>The deadline is <ins>Friday</ins>.</p>
```

### `<mark>` - Highlight
The `<mark>` element represents highlighted text. The default browser style is a yellow background, which this implementation matches.

**Example:**
```html
<p>Search result: The <mark>quick brown fox</mark> jumps over.</p>
```

## Changes
- `constants.py`: Added `'ins': 'underline'` to `FONT_STYLES`
- `h4d.py`: Added handler for `<mark>` that applies yellow (`#FFFF00`) background using `w:shd` shading element (consistent with existing background-color mechanism)

## Test plan
- [ ] Verify `<ins>text</ins>` renders with underline
- [ ] Verify `<mark>text</mark>` renders with yellow background
- [ ] Verify nesting works (e.g., `<mark><strong>bold highlight</strong></mark>`)
- [ ] Verify inline styles on `<mark>` can override the default yellow