### PR TITLE
Bug/handle invalid rolspan and colspan

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ Release History
 
 **Fixes**
 
-- None
+- Handle invalid rowspan and colspan values in tables. | `dfop02 <https://github.com/dfop02>`_ inspired by `PR #56 <https://github.com/dfop02/html4docx/pull/56>`_ from `kko-harvey <https://github.com/kko-harvey>`_ .
 
 **New Features**
 

--- a/html4docx/h4d.py
+++ b/html4docx/h4d.py
@@ -1295,8 +1295,8 @@ class HtmlToDocx(HTMLParser):
 
                 # Reference:
                 # https://python-docx.readthedocs.io/en/latest/dev/analysis/features/table/cell-merge.html
-                rowspan = int(col.get('rowspan', 1))
-                colspan = int(col.get('colspan', 1))
+                rowspan = utils.safe_int(col.get('rowspan', 1))
+                colspan = utils.safe_int(col.get('colspan', 1))
 
                 if rowspan > 1 or colspan > 1:
                     docx_cell = docx_cell.merge(
@@ -1752,12 +1752,12 @@ class HtmlToDocx(HTMLParser):
         for row_idx, row in enumerate(rows):
             cols = self.get_table_columns(row)
             # Handle colspan
-            row_col_count = sum(int(col.get('colspan', default_span)) for col in cols)
+            row_col_count = sum(utils.safe_int(col.get('colspan', default_span)) for col in cols)
             max_cols = max(max_cols, row_col_count)
 
             # Handle rowspan
             for col in cols:
-                rowspan = int(col.get('rowspan', default_span))
+                rowspan = utils.safe_int(col.get('rowspan', default_span))
                 if rowspan > default_span:
                     max_rows = max(max_rows, row_idx + rowspan)
 

--- a/html4docx/utils.py
+++ b/html4docx/utils.py
@@ -314,7 +314,14 @@ def check_style_exists(document, style_name):
     except Exception:
         return False
 
-# Moved from h4d.py to here.... was _parse_text_decoration
+
+def safe_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        return 1
+
+
 def parse_text_decoration(text_decoration):
     """Parse text-decoration using regex to preserve color values."""
     # Pattern to match color values (rgb, hex, named colors) or other tokens

--- a/tests/test_h4d.py
+++ b/tests/test_h4d.py
@@ -2643,5 +2643,25 @@ and blank lines.
         self.assertIn('Could not parse color \'invalidcolorname\': Invalid color value. Fallback to black.', log.output[3])
         self.assertIn('Could not parse color \'#f7272626161\': Invalid color value. Fallback to black.', log.output[4])
 
+    def test_invalid_rowspan_and_colspan(self):
+        """Test with invalid rowspan and colspan"""
+
+        html = '<table><tr><td rowspan="invalid">Test 1</td></tr></table>'
+
+        doc = Document()
+        parser = HtmlToDocx()
+        parser.add_html_to_document(html, self.document)
+        parser.add_html_to_document(html, doc)
+
+        self.assertEqual(len(doc.tables), 1)
+
+        table = doc.tables[0]
+
+        self.assertEqual(len(table.rows), 1)
+        self.assertEqual(len(table.columns), 1)
+
+        self.assertEqual(table.cell(0, 0).text.strip(), "Test 1")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Handle invalid rowspan and colspan values gracefully.

Instead of raising an exception and crashing when a non-numeric or invalid value is provided, we now default both attributes to 1. This ensures table rendering continues safely and aligns with standard HTML behavior, improving robustness and fault tolerance.

This fix was originally made by [kko-harvey](https://github.com/kko-harvey) on [PR#56](https://github.com/dfop02/html4docx/pull/56). The original PR was not merged and completed due to lack of response.

## Issue Reference

No Issue

## Checklist Before Requesting a Review

- [x] I have performed a self-review of my code.
- [x] My code follows the project's coding style and guidelines.
- [x] I have run tests and verified that all existing and new tests pass.
- [x] I have added new tests to cover my changes.
