### PR TITLE
Fixed non-breaking spaces.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,22 @@
 Release History
 ---------------
 
+1.1.7 (unreleased)
+++++++++++++++++++
+
+**Updates**
+
+- None
+
+**Fixes**
+
+- Non-breaking spaces (``&nbsp;``, U+00A0) and other non-ASCII spaces are no longer collapsed into ordinary spaces, so text kept deliberately on one line stays unbroken. | `Lynuxen <https://github.com/Lynuxen>`_
+
+**New Features**
+
+- None
+
+
 1.1.6 (2026-06-24)
 ++++++++++++++++++
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ My goal in forking and fixing/updating this package was to complete my current t
 - Fixed highlighting a single word | [Lynuxen](https://github.com/Lynuxen)
 - Fix color parsing failing due to invalid colors, falling back to black. | [dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/53)
 - Fix logging noise: replace root-logger calls with named module loggers so consumers can silence or configure html4docx output independently. | [dfop02](https://github.com/dfop02) from [Issue](https://github.com/dfop02/html4docx/issues/80)
+- Fixed non-breaking spaces (`&nbsp;`) being collapsed into ordinary spaces, which let Word break lines inside amounts like `1 000,00 €` | [Lynuxen](https://github.com/Lynuxen)
 
 **New Features**
 - Add Witdh/Height style to images | [maifeeulasad](https://github.com/maifeeulasad) from [PR](https://github.com/pqzx/html2docx/pull/29)

--- a/html4docx/utils.py
+++ b/html4docx/utils.py
@@ -21,6 +21,15 @@ class ImageAlignment(Enum):
     RIGHT = 3
 
 
+# The whitespace HTML collapses: ASCII space, tab, line feed, form feed and
+# carriage return. Deliberately narrower than ``\s``, which in Python also
+# matches the non-breaking space (U+00A0) and other Unicode spaces such as the
+# narrow no-break space (U+202F) or the figure space (U+2007). These are
+# meaningful characters, not layout whitespace, so they must not be collapsed.
+# https://infra.spec.whatwg.org/#ascii-whitespace
+HTML_WHITESPACE = r"[ \t\n\r\f]"
+
+
 def get_filename_from_url(url: str):
     return os.path.basename(urlparse(url).path)
 
@@ -310,19 +319,28 @@ def remove_whitespace(string, leading=False, trailing=False):
 
             >>> remove_whitespace("abc  \\n  ", trailing=True)
             'abc'
+
+        Non-breaking spaces (U+00A0, written ``&nbsp;`` in HTML) and other non-ASCII
+        spaces are not layout whitespace and are left untouched, so ``&nbsp;`` keeps
+        text on one line as intended:
+
+            >>> remove_whitespace("19\\u00a0000,00\\u00a0\\u20ac")
+            '19\\xa0000,00\\xa0€'
+            >>> remove_whitespace("abc \\n \\u00a0 def")
+            'abc \\xa0 def'
     """
     # Remove any leading new line characters along with any surrounding white space
     if leading:
-        string = re.sub(r"^\s*\n+\s*", "", string)
+        string = re.sub(rf"^{HTML_WHITESPACE}*\n+{HTML_WHITESPACE}*", "", string)
 
     # Remove any trailing new line characters along with any surrounding white space
     if trailing:
-        string = re.sub(r"\s*\n+\s*$", "", string)
+        string = re.sub(rf"{HTML_WHITESPACE}*\n+{HTML_WHITESPACE}*$", "", string)
 
     # Replace new line characters and absorb any surrounding space.
-    string = re.sub(r"\s*\n\s*", " ", string)
+    string = re.sub(rf"{HTML_WHITESPACE}*\n{HTML_WHITESPACE}*", " ", string)
     # TODO need some way to get rid of extra spaces in e.g. text <span>   </span>  text
-    return re.sub(r"\s+", " ", string)
+    return re.sub(rf"{HTML_WHITESPACE}+", " ", string)
 
 
 def delete_paragraph(paragraph):

--- a/tests/test_h4d.py
+++ b/tests/test_h4d.py
@@ -8,7 +8,7 @@ from docx import Document
 from docx.enum.style import WD_STYLE_TYPE
 from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_UNDERLINE
 from docx.oxml.ns import qn
-from docx.shared import Pt, RGBColor
+from docx.shared import Cm, Pt, RGBColor
 
 from html4docx import HtmlToDocx
 from html4docx.colors import Color
@@ -272,6 +272,53 @@ and blank lines.
 </pre>
 """
         self.parser.add_html_to_document(html, self.document)
+
+    def test_non_breaking_spaces_are_preserved(self):
+        nbsp_html = (
+            "<p>Montant :&nbsp;19&nbsp;000,00&nbsp;&euro;</p>"
+            "<p>Literal:\xa0kept</p>"
+            "<p>Narrow:\u202fkept</p>"
+        )
+
+        document = self.parser.parse_html_string(nbsp_html)
+        paragraphs = document.paragraphs
+
+        assert paragraphs[0].text == "Montant :\xa019\xa0000,00\xa0€"
+        assert paragraphs[1].text == "Literal:\xa0kept"
+        assert paragraphs[2].text == "Narrow:\u202fkept"
+
+        # The separator reaching Word must be a real U+00A0
+        amount = paragraphs[0]._p.findall(".//" + qn("w:t"))[0].text
+        assert amount.count("\xa0") == 3
+        # The one ordinary space, after "Montant", must stay ordinary.
+        assert amount.count(" ") == 1
+
+        # -------- human validation --------
+        # The editor decides line breaks, so the bug is only visible where a break
+        # falls inside the amount.
+        self.document.add_heading("Test: non-breaking spaces", level=1)
+        self.document.add_paragraph(
+            "The two justified paragraphs below differ only in the separators inside the "
+            'amount. The first must not break between "19" and "000,00"; the second uses '
+            "ordinary spaces and is expected to break there."
+        )
+        for separator in ("&nbsp;", " "):
+            first_paragraph = len(self.document.paragraphs)
+            self.parser.add_html_to_document(
+                '<p style="text-align: justify;">'
+                f"mot mot mot Total 19{separator}000,00{separator}&euro; fin</p>",
+                self.document,
+            )
+            for paragraph in self.document.paragraphs[first_paragraph:]:
+                # 10.25-11.25cm all break inside the amount; midpoint chosen for margin.
+                paragraph.paragraph_format.right_indent = Cm(10.75)
+
+    def test_ordinary_whitespace_is_still_collapsed(self):
+        whitespace_html = "<p>collapse   these \n\n  spaces\t\tplease</p>"
+
+        document = self.parser.parse_html_string(whitespace_html)
+
+        assert document.paragraphs[0].text == "collapse these spaces please"
 
     def test_handling_hr(self):
         hr_html_example = "<p>paragraph</p><hr><p>paragraph</p>"


### PR DESCRIPTION
## Description

`remove_whitespace()` collapsed non-breaking spaces into ordinary spaces, so `&nbsp;` had no effect in the output document. Text that was deliberately kept on one line could be broken by Word, e.g. an amount written `19&nbsp;000,00&nbsp;€` would wrap as "19" / "000,00 €" in a justified paragraph.

## Checklist Before Requesting a Review

- [x ] I have performed a self-review of my code.
- [x ] My code follows the project's coding style and guidelines.
- [x ] I have run tests and verified that all existing and new tests pass.
- [x ] I have added new tests to cover my changes.
